### PR TITLE
Fixed the issue by updating libraries - it runs again

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -5,3 +5,5 @@ backgroundColor="#ffffff"
 secondaryBackgroundColor="#e8eef9"
 textColor="#000000"
 font="sans serif"
+[client]
+showErrorDetails = false #this is to remove the cache error from showing - take this out when debugging

--- a/nhstheme.py
+++ b/nhstheme.py
@@ -7,10 +7,10 @@
 """
 FILE:           nhstheme.py
 DESCRIPTION:    Streamlit NHS Theme Template
-CONTRIBUTORS:   Craig Shenton, Mattia Ficarelli   
-CONTACT:        craig.shenton@nhs.net
+CONTRIBUTORS:   Craig Shenton, Mattia Ficarelli, Sam Hollings   
+CONTACT:        nhspythoncommunity@england.nhs.uk
 CREATED:        2022-01-19
-VERSION:        0.0.1
+VERSION:        0.0.2
 """
 
 # Libraries

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-pandas~=1.3.1
-streamlit~=1.3.0
-streamlit-aggrid~=0.2.2.post4
-streamlit_folium~=0.4.0
-regex~=2021.11.10
+pandas~=2.2.3
+streamlit~=1.39.0
+streamlit-aggrid~=1.0.5
+streamlit_folium~=0.23.1
+regex~=2024.9.11
+protobuf~=3.19.0


### PR DESCRIPTION
A colleague said they couldn't get the template to run - so by updating the dependencies we were able to get it running again.

Dependencies updates:
requirements.txt
Fixed the versions at newer versions so that it runs.

Configuration updates:

* [`.streamlit/config.toml`](diffhunk://#diff-a7f7962e3e1209cfc31a2d3faee8dd8fdd5341f7249033e948c6539eae0a47c3R8-R9): Added a client configuration to hide error details (`showErrorDetails = false`) to prevent cache errors from displaying. This should be removed during debugging.

Documentation updates:

* [`nhstheme.py`](diffhunk://#diff-539db6cdadae177f8cc808a489d1a0abf7edc69f457f2b3123999ccc4da9f36bL10-R13): Updated the contributors list to include Sam Hollings and changed the contact email to `nhspythoncommunity@england.nhs.uk`. Also updated the version from `0.0.1` to `0.0.2`.